### PR TITLE
Improve docs for firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository showcases several demos built around the LX34070A inductive sens
 - **`InductiveSensorDemo.py`** – PyQt6 version of the resolver signal monitor built with `pyqtgraph`.
 - **`InductiveSensorDemoTk.py`** – Tkinter variant of the resolver demo using `matplotlib` for plotting.
 - **`MotorLogger.py`** – A feature-rich logger that can start/stop the motor, log up to five variables with per-channel scaling and export the data.
-- **`main.c`** – Minimal firmware reading raw sine/cosine values and exposing them, along with the calculated position, via X2Cscope. This is the meain.c file running in the dsPIC33CK. for the whole project extract the .zip file provided and open it through mplabXide. the .elf file can also be founf in the project folder in the .dist directory.
+- **`main.c`** – Minimal firmware that samples the LX34070A resolver, normalises the data and publishes it via X2Cscope. It also drives quadrature A/B/Z outputs so the board can serve as a resolver-to-encoder converter. This is the `main.c` file running on the dsPIC33CK; extract the accompanying project zip and open it in MPLAB X IDE to rebuild. The compiled ELF is under the `dist` folder.
 
 ## Features
 
@@ -62,8 +62,7 @@ This repository showcases several demos built around the LX34070A inductive sens
 3. For the gauge demos, use **Change View** to cycle through the different widgets.
 4. In `MotorLogger.py`, set the desired speed, scaling factor and sample interval then press **START**. Use **STOP** to end the capture early, plot the results or save them to file.
 5. `InductiveSensorDemo.py` and `InductiveSensorDemoTk.py` display sine and cosine signals along with the calculated angle. Both offer basic trigger options.
-6. `main.c` shows how the MCU collects ADC samples, normalizes them and exposes variables to X2Cscope.
-
+6. `main.c` shows how the MCU collects ADC samples, normalizes them and exposes variables to X2Cscope. It also demonstrates generating A/B/Z pulses, turning the resolver into an incremental encoder.
 ## How the Pieces Fit Together
 
 The firmware periodically samples the resolver signals and computes the position using `atan2f`. These variables are exposed through X2Cscope so the Python GUIs can read them. The GUIs rely on a small wrapper class that hides the difference between real hardware and demo mode. Each demo updates its widgets every few milliseconds using `QTimer` or Tkinter's `after` callbacks. The logger additionally configures scope channels to capture all variables at a fixed rate and writes the scaled values to memory before optionally saving them.

--- a/main.c
+++ b/main.c
@@ -31,6 +31,17 @@
 #include "mcc_generated_files/timer/sccp2.h" // TODO: Replace {timer_header} with the corresponding timer header file for your project (ex: tmr1.h)
 
 #include <math.h> // For atan2f
+/*
+ * Demo firmware reading LX34070A resolver signals on a dsPIC33CK.
+ * The ADC collects sine and cosine, normalises them and computes
+ * the angle via atan2f. All values are published through X2Cscope
+ * so the Python GUIs can display them.
+ *
+ * The code also outputs quadrature A/B/Z pulses on RB7-9. With a
+ * suitable count setting, the board becomes a resolver-to-encoder
+ * converter that plugs into any controller expecting standard
+ * incremental feedback.
+ */
 
 // ---------------------------------------------------------------------------
 // Encoder GPIO helper macros (using RB7/RB8/RB9 for A/B/Z)
@@ -103,6 +114,9 @@ static void Blink_LED(void)
 }
 
 // Convert resolver_position to quadrature encoder signals
+// Each mechanical revolution is split into counts_per_rev increments,
+// producing standard A/B/Z pulses so external drives can treat the
+// resolver like an incremental encoder.
 static void UpdateEncoderOutputs(void)
 {
     float angle = resolver_position;


### PR DESCRIPTION
## Summary
- expand `main.c` description
- document quadrature output as resolver-to-encoder feature
- clarify bullet in README

## Testing
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_688944d6443883239d8c5fe4ad7b654e